### PR TITLE
 Add Windows-compatible MCP Server Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ Run blender-mcp without installing it permanently through uvx. Go to Cursor Sett
 uvx blender-mcp
 ```
 
+For Windows users, go to Settings > MCP > Add Server, add a new server with the following settings:
+
+```json
+{
+    "mcpServers": {
+        "blender": {
+            "command": "cmd",
+            "args": [
+                "/c",
+                "uvx",
+                "blender-mcp"
+            ]
+        }
+    }
+}
+```
+
+
 [Cursor setup video](https://www.youtube.com/watch?v=wgWsJshecac)
 
 **⚠️ Only run one instance of the MCP server (either on Cursor or Claude Desktop), not both**


### PR DESCRIPTION
Fixed Windows compatibility:
   - Added Windows-specific MCP server configuration using `cmd /c` command
   - Previous configuration was not working on Windows systems
   - Tested and verified working on Windows 10/11

These changes ensure Windows users can successfully set up and run the Blender MCP integration without configuration issues.