### PR TITLE
Fix for create_object(type="PLANE") when scale given.

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -370,7 +370,8 @@ class BlenderMCPServer:
                     obj.data.name = name
             
             # Patch for PLANE: scale don't work with bpy.ops.mesh.primitive_plane_add()
-            obj.scale = scale
+            if type in {"PLANE"}:
+                obj.scale = scale
 
             # Return the object info
             result = {

--- a/addon.py
+++ b/addon.py
@@ -369,6 +369,9 @@ class BlenderMCPServer:
                 if obj.data:
                     obj.data.name = name
             
+            # Patch for PLANE: scale don't work with bpy.ops.mesh.primitive_plane_add()
+            obj.scale = scale
+
             # Return the object info
             result = {
                 "name": obj.name,


### PR DESCRIPTION
### **User description**
According to [blender dev](https://projects.blender.org/blender/blender/issues/82211#issuecomment-274202), planes created using `bpy.ops.mesh.primitive_plane_add` will ignore the scale parameter. So I added a small piece of code to apply the scaling to the created plane.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed scaling issue for `PLANE` objects in `create_object`.

- Applied scale manually after object creation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>addon.py</strong><dd><code>Fix scaling for `PLANE` objects in `create_object`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

addon.py

<li>Added manual scaling for <code>PLANE</code> objects.<br> <li> Addressed limitation of <code>bpy.ops.mesh.primitive_plane_add</code>.


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/84/files#diff-a00fabecb6c13a84bae446368347ab0da61ce323e65e01afdbbbb9639cd17605">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with plane object scaling so that they now display at the intended size during creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->