### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 BlenderMCP connects Blender to Claude AI through the Model Context Protocol (MCP), allowing Claude to directly interact with and control Blender. This integration enables prompt assisted 3D modeling, scene creation, and manipulation.
 
+<a href="https://glama.ai/mcp/servers/@ahujasid/blender-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ahujasid/blender-mcp/badge" alt="BlenderMCP MCP server" />
+</a>
+
 [Full tutorial](https://www.youtube.com/watch?v=lCyQ717DuzQ)
 
 ### Join the Community


### PR DESCRIPTION
This PR adds a badge for the [BlenderMCP](https://glama.ai/mcp/servers/@ahujasid/blender-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ahujasid/blender-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ahujasid/blender-mcp/badge" alt="BlenderMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.