### PR TITLE
add environment variables configuration for Blender connection host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ Otherwise installation instructions are on their website: [Install uv](https://d
 
 **⚠️ Do not proceed before installing UV**
 
+### Environment Variables
+
+The following environment variables can be used to configure the Blender connection:
+
+- `BLENDER_HOST`: Host address for Blender socket server (default: "localhost")
+- `BLENDER_PORT`: Port number for Blender socket server (default: 9876)
+
+Example:
+```bash
+export BLENDER_HOST='host.docker.internal'
+export BLENDER_PORT=9876
+```
 
 ### Claude for Desktop Integration
 

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -18,6 +18,10 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("BlenderMCPServer")
 
+# Default configuration
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 9876
+
 @dataclass
 class BlenderConnection:
     host: str
@@ -226,7 +230,9 @@ def get_blender_connection():
     
     # Create a new connection if needed
     if _blender_connection is None:
-        _blender_connection = BlenderConnection(host="localhost", port=9876)
+        host = os.getenv("BLENDER_HOST", DEFAULT_HOST)
+        port = int(os.getenv("BLENDER_PORT", DEFAULT_PORT))
+        _blender_connection = BlenderConnection(host=host, port=port)
         if not _blender_connection.connect():
             logger.error("Failed to connect to Blender")
             _blender_connection = None


### PR DESCRIPTION
### **User description**
# Add Environment Variable Support for Blender Connection

## Changes
- Add `BLENDER_HOST` and `BLENDER_PORT` environment variables
- Default values: localhost:9876
- Update README with configuration docs

## Why
- Enable remote Blender connections
- Support containerized deployments of MCPs
- Make connection settings configurable without code changes

## Testing
1. Default behavior unchanged
2. Set custom host/port via env vars
3. Verify connection works with custom settings


___

### **PR Type**
Enhancement


___

### **Description**
• Add environment variable support for Blender connection configuration
• Enable configurable host and port settings via `BLENDER_HOST` and `BLENDER_PORT`
• Update documentation with configuration examples
• Support remote and containerized Blender deployments


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Environment variable support for connection settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/blender_mcp/server.py

• Add default constants for host and port configuration<br> • Replace <br>hardcoded connection values with environment variable lookup<br> • Use <br><code>os.getenv()</code> to read <code>BLENDER_HOST</code> and <code>BLENDER_PORT</code> with fallback <br>defaults


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/126/files#diff-9d7e3cb4a2dd22ba7b1b7a62a2457e95ae4d0924bcd9a1cd5840f510086433d3">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Documentation for environment variable configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

• Add new "Environment Variables" section with configuration <br>documentation<br> • Document <code>BLENDER_HOST</code> and <code>BLENDER_PORT</code> variables with <br>defaults<br> • Provide usage example with Docker host configuration


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/126/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connection settings for the Blender socket server can now be configured using environment variables (`BLENDER_HOST` and `BLENDER_PORT`), with sensible defaults provided.
- **Documentation**
  - Added instructions to the README on how to set environment variables for configuring the Blender server connection, including usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->