### PR TITLE
Fix: Use command line port argument instead of hardcoded value

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,28 @@ Go to Claude > Settings > Developer > Edit Config > claude_desktop_config.json t
 }
 ```
 
+#### Custom Port Configuration
+
+By default, the MCP server connects to Blender on port 9876. You can change this by adding the `--port` argument:
+
+```json
+{
+    "mcpServers": {
+        "blender": {
+            "command": "uvx",
+            "args": [
+                "blender-mcp",
+                "--port",
+                "8080"
+            ]
+        }
+    }
+}
+```
+
+Make sure the port number matches the one shown in Blender's BlenderMCP panel.
+
+
 ### Cursor integration
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=blender&config=eyJjb21tYW5kIjoidXZ4IGJsZW5kZXItbWNwIn0%3D)


### PR DESCRIPTION
### **User description**
- Fixed hardcoded port 9876 in get_blender_connection()
- Added documentation for --port configuration in README

## Problem
The --port command line argument was being ignored due to hardcoded port 9876 in get_blender_connection().

## Solution
- Fixed hardcoded port 9876 in get_blender_connection()
- Added documentation for --port configuration in README

## Testing
- Tested with custom port (8080) ✓
- Tested with default port (9876) ✓


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed hardcoded port 9876 to use command line argument

- Added --port argument parsing with default value 9876

- Enhanced error messages to include port information

- Added README documentation for custom port configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Replace hardcoded port with configurable argument</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/blender_mcp/server.py

<li>Added <code>argparse</code> import and command line argument parsing<br> <li> Introduced global <code>_blender_port</code> variable with default value 9876<br> <li> Modified <code>get_blender_connection()</code> to use configurable port instead of <br>hardcoded 9876<br> <li> Enhanced error messages to include port information in logs


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/129/files#diff-9d7e3cb4a2dd22ba7b1b7a62a2457e95ae4d0924bcd9a1cd5840f510086433d3">+20/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add port configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added "Custom Port Configuration" section with JSON example<br> <li> Documented how to use <code>--port</code> argument in Claude desktop config<br> <li> Added note about matching port with Blender's BlenderMCP panel


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/129/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to customize the port used for connecting to Blender via a command-line argument or configuration file.
* **Documentation**
  * Updated integration instructions to include a section on custom port configuration, with an example for specifying a custom port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->