### PR TITLE
bugfix: remove description in FastMCP

### DIFF
--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -193,7 +193,6 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Create the MCP server with lifespan support
 mcp = FastMCP(
     "BlenderMCP",
-    description="Blender integration through the Model Context Protocol",
     lifespan=server_lifespan
 )
 


### PR DESCRIPTION
# Fix: Remove unsupported 'description' argument from FastMCP init

## Summary

This PR fixes a compatibility issue with the latest `fastmcp` library.
According to the official docs ([FastMCP Documentation](https://gofastmcp.com/servers/server#param-instructions)),
the `description` parameter has been removed from `FastMCP.__init__()`.

Before this fix, running the Blender MCP server caused:

```
TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'
```

---

## Changes

- Removed the unsupported `description` argument from `src/blender_mcp/server.py`.

