### PR TITLE
Add Remote Host Configuration Support for Blender MCP Server

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1769,7 +1769,7 @@ class BLENDERMCP_OT_StopServer(bpy.types.Operator):
 def register():
     bpy.types.Scene.blendermcp_addr = bpy.props.StringProperty(
         name="Address",
-        description="Listener address for the BlenderMCP server",
+        description="Listener address for the BlenderMCP server. Use 127.0.0.1 for localhost, 0.0.0.0 for all interfaces (security risk on untrusted networks), or a specific IP address",
         default="127.0.0.1"
     )
     

--- a/addon.py
+++ b/addon.py
@@ -29,7 +29,7 @@ bl_info = {
 RODIN_FREE_TRIAL_KEY = "k9TcfFoEhNd9cCPP2guHAHHHkctZHIRhZDywZ1euGUXwihbYLpOjQhofby80NJez"
 
 class BlenderMCPServer:
-    def __init__(self, host='localhost', port=9876):
+    def __init__(self, host='0.0.0.0', port=9876):
         self.host = host
         self.port = port
         self.running = False

--- a/addon.py
+++ b/addon.py
@@ -1696,7 +1696,8 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         scene = context.scene
-        
+
+        layout.prop(scene, "blendermcp_addr")
         layout.prop(scene, "blendermcp_port")
         layout.prop(scene, "blendermcp_use_polyhaven", text="Use assets from Poly Haven")
 
@@ -1771,6 +1772,7 @@ def register():
         description="Listener address for the BlenderMCP server",
         default="127.0.0.1"
     )
+    
     bpy.types.Scene.blendermcp_port = IntProperty(
         name="Port",
         description="Port for the BlenderMCP server",
@@ -1843,7 +1845,8 @@ def unregister():
     bpy.utils.unregister_class(BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey)
     bpy.utils.unregister_class(BLENDERMCP_OT_StartServer)
     bpy.utils.unregister_class(BLENDERMCP_OT_StopServer)
-    
+
+    del bpy.types.Scene.blendermcp_addr
     del bpy.types.Scene.blendermcp_port
     del bpy.types.Scene.blendermcp_server_running
     del bpy.types.Scene.blendermcp_use_polyhaven

--- a/addon.py
+++ b/addon.py
@@ -29,7 +29,7 @@ bl_info = {
 RODIN_FREE_TRIAL_KEY = "k9TcfFoEhNd9cCPP2guHAHHHkctZHIRhZDywZ1euGUXwihbYLpOjQhofby80NJez"
 
 class BlenderMCPServer:
-    def __init__(self, host='0.0.0.0', port=9876):
+    def __init__(self, host='127.0.0.1', port=9876):
         self.host = host
         self.port = port
         self.running = False
@@ -1738,7 +1738,7 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
         
         # Create a new server instance
         if not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server:
-            bpy.types.blendermcp_server = BlenderMCPServer(port=scene.blendermcp_port)
+            bpy.types.blendermcp_server = BlenderMCPServer(host=scene.blendermcp_addr, port=scene.blendermcp_port)
         
         # Start the server
         bpy.types.blendermcp_server.start()
@@ -1766,6 +1766,11 @@ class BLENDERMCP_OT_StopServer(bpy.types.Operator):
 
 # Registration functions
 def register():
+    bpy.types.Scene.blendermcp_addr = bpy.props.StringProperty(
+        name="Address",
+        description="Listener address for the BlenderMCP server",
+        default="127.0.0.1"
+    )
     bpy.types.Scene.blendermcp_port = IntProperty(
         name="Port",
         description="Port for the BlenderMCP server",

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -32,8 +32,9 @@ class BlenderConnection:
         try:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             HOST = os.getenv("BLENDER_MCP_HOST", self.host)
-            self.sock.connect((HOST, self.port))
-            logger.info(f"Connected to Blender at {HOST}:{self.port}")
+            PORT = os.getenv("BLENDER_MCP_PORT", self.port)
+            self.sock.connect((HOST, PORT))
+            logger.info(f"Connected to Blender at {HOST}:{PORT}")
             return True
         except Exception as e:
             logger.error(f"Failed to connect to Blender: {str(e)}")

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -31,7 +31,8 @@ class BlenderConnection:
             
         try:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.sock.connect((self.host, self.port))
+            HOST = os.getenv("BLENDER_MCP_HOST", self.host)
+            self.sock.connect((HOST, self.port))
             logger.info(f"Connected to Blender at {self.host}:{self.port}")
             return True
         except Exception as e:

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -33,7 +33,7 @@ class BlenderConnection:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             HOST = os.getenv("BLENDER_MCP_HOST", self.host)
             self.sock.connect((HOST, self.port))
-            logger.info(f"Connected to Blender at {self.host}:{self.port}")
+            logger.info(f"Connected to Blender at {HOST}:{self.port}")
             return True
         except Exception as e:
             logger.error(f"Failed to connect to Blender: {str(e)}")


### PR DESCRIPTION
### **User description**
This pull request adds support for configuring a remote host connection for the Blender MCP server, enabling users to run Blender on a different machine while connecting from Claude Desktop.

## Changes Made

### Blender Addon Updates
- Added a new **Host Address** setting to the Blender MCP panel in the addon interface
- Default value is set to `127.0.0.1` (localhost) for backward compatibility
- The setting allows users to specify which network interface the MCP server should bind to
- Updated the server initialization to use the configured host address

### MCP Server Configuration
- Added `BLENDER_MCP_HOST` environment variable support
- Updated the sample configuration to demonstrate remote host setup (`192.168.51.2` in example)
- The server now respects the environment variable for host binding

## Usage Instructions

### For Remote Blender Setup:
1. **On the remote machine**: Start Blender with the MCP addon and configure the host address in the panel (e.g., `192.168.1.100`)
2. **On the Claude Desktop machine**: Update your MCP server configuration to include the `BLENDER_MCP_HOST` environment variable pointing to the remote machine
3. Start Claude Desktop
4. The connection will now work across the network

### Configuration Example:
```json
{
    "mcpServers": {
        "blender": {
            "command": "uvx",
            "args": [
                "blender-mcp"
            ],
            "env": {
                "BLENDER_MCP_HOST": "192.168.1.100"
            }
        }
    }
}
```

## Benefits
- Enables distributed workflows where Blender runs on a dedicated workstation/server
- Maintains full backward compatibility with existing localhost setups
- Provides flexibility for various network configurations
- No breaking changes to existing installations


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable host address support for remote connections

- Enable environment variable configuration for host and port

- Maintain backward compatibility with localhost default

- Support distributed Blender workflows across network


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Blender Addon"] -- "configurable address" --> B["MCP Server"]
  B -- "BLENDER_MCP_HOST env" --> C["Remote Connection"]
  D["Claude Desktop"] -- "network connection" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>addon.py</strong><dd><code>Add configurable host address to Blender addon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

addon.py

<ul><li>Add <code>blendermcp_addr</code> property for configurable host address<br> <li> Update UI panel to include address field with security description<br> <li> Modify server initialization to use configured host address<br> <li> Change default host from 'localhost' to '127.0.0.1'</ul>


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/146/files#diff-a00fabecb6c13a84bae446368347ab0da61ce323e65e01afdbbbb9639cd17605">+12/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Add environment variable support for connection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/blender_mcp/server.py

<ul><li>Add support for <code>BLENDER_MCP_HOST</code> environment variable<br> <li> Add support for <code>BLENDER_MCP_PORT</code> environment variable<br> <li> Update connection logic to use environment variables when available<br> <li> Improve logging to show actual connection parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/146/files#diff-9d7e3cb4a2dd22ba7b1b7a62a2457e95ae4d0924bcd9a1cd5840f510086433d3">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable address field in the Blender UI for the server listener, allowing users to specify which network interface the server should bind to.
  * The server connection can now be customized via environment variables for both host and port.

* **Improvements**
  * Enhanced tooltips in the UI to clarify address options and their security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->