### PR TITLE
fix: persist API keys across Blender sessions

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -23,12 +23,115 @@ from contextlib import redirect_stdout, suppress
 bl_info = {
     "name": "Blender MCP",
     "author": "BlenderMCP",
-    "version": (1, 2),
+    "version": (1, 3),
     "blender": (3, 0, 0),
     "location": "View3D > Sidebar > BlenderMCP",
     "description": "Connect Blender to Claude via MCP",
     "category": "Interface",
 }
+
+
+def get_addon_preferences():
+    """Get addon preferences, handling both old and new Blender API"""
+    addon_name = __name__ if __name__ != "__main__" else "blender_mcp"
+    addon = bpy.context.preferences.addons.get(addon_name)
+    if addon:
+        return addon.preferences
+    return None
+
+
+def get_api_key(key_name):
+    """
+    Get API key from addon preferences with fallback to scene properties.
+
+    This provides backward compatibility: if a key exists in the old scene
+    property location, it will be used. New keys are stored in preferences.
+    """
+    prefs = get_addon_preferences()
+    scene = bpy.context.scene
+
+    key_mapping = {
+        "sketchfab": ("sketchfab_api_key", "blendermcp_sketchfab_api_key"),
+        "hyper3d": ("hyper3d_api_key", "blendermcp_hyper3d_api_key"),
+        "hunyuan3d_secret_id": ("hunyuan3d_secret_id", "blendermcp_hunyuan3d_secret_id"),
+        "hunyuan3d_secret_key": ("hunyuan3d_secret_key", "blendermcp_hunyuan3d_secret_key"),
+    }
+
+    if key_name not in key_mapping:
+        return ""
+
+    pref_attr, scene_attr = key_mapping[key_name]
+
+    # Try preferences first (new persistent storage)
+    if prefs and hasattr(prefs, pref_attr):
+        key = getattr(prefs, pref_attr, "")
+        if key:
+            return key
+
+    # Fallback to scene property (backward compatibility)
+    if hasattr(scene, scene_attr):
+        return getattr(scene, scene_attr, "")
+
+    return ""
+
+
+def set_api_key(key_name, value):
+    """Set API key in addon preferences."""
+    prefs = get_addon_preferences()
+    if not prefs:
+        return False
+
+    key_mapping = {
+        "sketchfab": "sketchfab_api_key",
+        "hyper3d": "hyper3d_api_key",
+        "hunyuan3d_secret_id": "hunyuan3d_secret_id",
+        "hunyuan3d_secret_key": "hunyuan3d_secret_key",
+    }
+
+    if key_name in key_mapping:
+        setattr(prefs, key_mapping[key_name], value)
+        return True
+    return False
+
+
+class BlenderMCPPreferences(bpy.types.AddonPreferences):
+    """Addon preferences for storing API keys persistently"""
+    bl_idname = __name__ if __name__ != "__main__" else "blender_mcp"
+
+    sketchfab_api_key: bpy.props.StringProperty(
+        name="Sketchfab API Key",
+        subtype="PASSWORD",
+        description="API Key provided by Sketchfab (persists across sessions)",
+        default=""
+    )
+
+    hyper3d_api_key: bpy.props.StringProperty(
+        name="Hyper3D API Key",
+        subtype="PASSWORD",
+        description="API Key provided by Hyper3D (persists across sessions)",
+        default=""
+    )
+
+    hunyuan3d_secret_id: bpy.props.StringProperty(
+        name="Hunyuan3D SecretId",
+        description="SecretId provided by Hunyuan3D (persists across sessions)",
+        default=""
+    )
+
+    hunyuan3d_secret_key: bpy.props.StringProperty(
+        name="Hunyuan3D SecretKey",
+        subtype="PASSWORD",
+        description="SecretKey provided by Hunyuan3D (persists across sessions)",
+        default=""
+    )
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text="API Keys (stored persistently):")
+        layout.prop(self, "sketchfab_api_key")
+        layout.prop(self, "hyper3d_api_key")
+        layout.prop(self, "hunyuan3d_secret_id")
+        layout.prop(self, "hunyuan3d_secret_key")
 
 RODIN_FREE_TRIAL_KEY = "k9TcfFoEhNd9cCPP2guHAHHHkctZHIRhZDywZ1euGUXwihbYLpOjQhofby80NJez"
 
@@ -1126,7 +1229,7 @@ class BlenderMCPServer:
         """Get the current status of Hyper3D Rodin integration"""
         enabled = bpy.context.scene.blendermcp_use_hyper3d
         if enabled:
-            if not bpy.context.scene.blendermcp_hyper3d_api_key:
+            if not get_api_key("hyper3d"):
                 return {
                     "enabled": False,
                     "message": """Hyper3D Rodin integration is currently enabled, but API key is not given. To enable it:
@@ -1136,8 +1239,9 @@ class BlenderMCPServer:
                                 4. Restart the connection to Claude"""
                 }
             mode = bpy.context.scene.blendermcp_hyper3d_mode
-            message = f"Hyper3D Rodin integration is enabled and ready to use. Mode: {mode}. " + \
-                f"Key type: {'private' if bpy.context.scene.blendermcp_hyper3d_api_key != RODIN_FREE_TRIAL_KEY else 'free_trial'}"
+            hyper3d_key = get_api_key("hyper3d")
+            key_type = "private" if hyper3d_key != RODIN_FREE_TRIAL_KEY else "free_trial"
+            message = f"Hyper3D Rodin integration is enabled and ready to use. Mode: {mode}. Key type: {key_type}"
             return {
                 "enabled": True,
                 "message": message
@@ -1182,7 +1286,7 @@ class BlenderMCPServer:
             response = requests.post(
                 "https://hyperhuman.deemos.com/api/v2/rodin",
                 headers={
-                    "Authorization": f"Bearer {bpy.context.scene.blendermcp_hyper3d_api_key}",
+                    "Authorization": f"Bearer {get_api_key('hyper3d')}",
                 },
                 files=files
             )
@@ -1210,7 +1314,7 @@ class BlenderMCPServer:
             response = requests.post(
                 "https://queue.fal.run/fal-ai/hyper3d/rodin",
                 headers={
-                    "Authorization": f"Key {bpy.context.scene.blendermcp_hyper3d_api_key}",
+                    "Authorization": f"Key {get_api_key('hyper3d')}",
                     "Content-Type": "application/json",
                 },
                 json=req_data
@@ -1234,7 +1338,7 @@ class BlenderMCPServer:
         response = requests.post(
             "https://hyperhuman.deemos.com/api/v2/status",
             headers={
-                "Authorization": f"Bearer {bpy.context.scene.blendermcp_hyper3d_api_key}",
+                "Authorization": f"Bearer {get_api_key('hyper3d')}",
             },
             json={
                 "subscription_key": subscription_key,
@@ -1250,7 +1354,7 @@ class BlenderMCPServer:
         response = requests.get(
             f"https://queue.fal.run/fal-ai/hyper3d/requests/{request_id}/status",
             headers={
-                "Authorization": f"KEY {bpy.context.scene.blendermcp_hyper3d_api_key}",
+                "Authorization": f"KEY {get_api_key('hyper3d')}",
             },
         )
         data = response.json()
@@ -1337,7 +1441,7 @@ class BlenderMCPServer:
         response = requests.post(
             "https://hyperhuman.deemos.com/api/v2/download",
             headers={
-                "Authorization": f"Bearer {bpy.context.scene.blendermcp_hyper3d_api_key}",
+                "Authorization": f"Bearer {get_api_key('hyper3d')}",
             },
             json={
                 'task_uuid': task_uuid
@@ -1403,7 +1507,7 @@ class BlenderMCPServer:
         response = requests.get(
             f"https://queue.fal.run/fal-ai/hyper3d/requests/{request_id}",
             headers={
-                "Authorization": f"Key {bpy.context.scene.blendermcp_hyper3d_api_key}",
+                "Authorization": f"Key {get_api_key('hyper3d')}",
             }
         )
         data_ = response.json()
@@ -1461,7 +1565,7 @@ class BlenderMCPServer:
     def get_sketchfab_status(self):
         """Get the current status of Sketchfab integration"""
         enabled = bpy.context.scene.blendermcp_use_sketchfab
-        api_key = bpy.context.scene.blendermcp_sketchfab_api_key
+        api_key = get_api_key("sketchfab")
 
         # Test the API key if present
         if api_key:
@@ -1523,7 +1627,7 @@ class BlenderMCPServer:
     def search_sketchfab_models(self, query, categories=None, count=20, downloadable=True):
         """Search for models on Sketchfab based on query and optional filters"""
         try:
-            api_key = bpy.context.scene.blendermcp_sketchfab_api_key
+            api_key = get_api_key("sketchfab")
             if not api_key:
                 return {"error": "Sketchfab API key is not configured"}
 
@@ -1585,7 +1689,7 @@ class BlenderMCPServer:
     def download_sketchfab_model(self, uid):
         """Download a model from Sketchfab by its UID"""
         try:
-            api_key = bpy.context.scene.blendermcp_sketchfab_api_key
+            api_key = get_api_key("sketchfab")
             if not api_key:
                 return {"error": "Sketchfab API key is not configured"}
 
@@ -1711,7 +1815,7 @@ class BlenderMCPServer:
         if enabled:
             match hunyuan3d_mode:
                 case "OFFICIAL_API":
-                    if not bpy.context.scene.blendermcp_hunyuan3d_secret_id or not bpy.context.scene.blendermcp_hunyuan3d_secret_key:
+                    if not get_api_key("hunyuan3d_secret_id") or not get_api_key("hunyuan3d_secret_key"):
                         return {
                             "enabled": False, 
                             "mode": hunyuan3d_mode, 
@@ -1846,8 +1950,8 @@ class BlenderMCPServer:
         image: str = None
     ):
         try:
-            secret_id = bpy.context.scene.blendermcp_hunyuan3d_secret_id
-            secret_key = bpy.context.scene.blendermcp_hunyuan3d_secret_key
+            secret_id = get_api_key("hunyuan3d_secret_id")
+            secret_key = get_api_key("hunyuan3d_secret_key")
 
             if not secret_id or not secret_key:
                 return {"error": "SecretId or SecretKey is not given"}
@@ -1997,8 +2101,8 @@ class BlenderMCPServer:
         """Call the job status API to get the job status"""
         print(job_id)
         try:
-            secret_id = bpy.context.scene.blendermcp_hunyuan3d_secret_id
-            secret_key = bpy.context.scene.blendermcp_hunyuan3d_secret_key
+            secret_id = get_api_key("hunyuan3d_secret_id")
+            secret_key = get_api_key("hunyuan3d_secret_key")
 
             if not secret_id or not secret_key:
                 return {"error": "SecretId or SecretKey is not given"}
@@ -2125,6 +2229,7 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         scene = context.scene
+        prefs = get_addon_preferences()
 
         layout.prop(scene, "blendermcp_port")
         layout.prop(scene, "blendermcp_use_polyhaven", text="Use assets from Poly Haven")
@@ -2132,26 +2237,29 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         layout.prop(scene, "blendermcp_use_hyper3d", text="Use Hyper3D Rodin 3D model generation")
         if scene.blendermcp_use_hyper3d:
             layout.prop(scene, "blendermcp_hyper3d_mode", text="Rodin Mode")
-            layout.prop(scene, "blendermcp_hyper3d_api_key", text="API Key")
+            if prefs:
+                layout.prop(prefs, "hyper3d_api_key", text="API Key")
             layout.operator("blendermcp.set_hyper3d_free_trial_api_key", text="Set Free Trial API Key")
 
         layout.prop(scene, "blendermcp_use_sketchfab", text="Use assets from Sketchfab")
         if scene.blendermcp_use_sketchfab:
-            layout.prop(scene, "blendermcp_sketchfab_api_key", text="API Key")
+            if prefs:
+                layout.prop(prefs, "sketchfab_api_key", text="API Key")
 
         layout.prop(scene, "blendermcp_use_hunyuan3d", text="Use Tencent Hunyuan 3D model generation")
         if scene.blendermcp_use_hunyuan3d:
             layout.prop(scene, "blendermcp_hunyuan3d_mode", text="Hunyuan3D Mode")
             if scene.blendermcp_hunyuan3d_mode == 'OFFICIAL_API':
-                layout.prop(scene, "blendermcp_hunyuan3d_secret_id", text="SecretId")
-                layout.prop(scene, "blendermcp_hunyuan3d_secret_key", text="SecretKey")
+                if prefs:
+                    layout.prop(prefs, "hunyuan3d_secret_id", text="SecretId")
+                    layout.prop(prefs, "hunyuan3d_secret_key", text="SecretKey")
             if scene.blendermcp_hunyuan3d_mode == 'LOCAL_API':
                 layout.prop(scene, "blendermcp_hunyuan3d_api_url", text="API URL")
                 layout.prop(scene, "blendermcp_hunyuan3d_octree_resolution", text="Octree Resolution")
                 layout.prop(scene, "blendermcp_hunyuan3d_num_inference_steps", text="Number of Inference Steps")
                 layout.prop(scene, "blendermcp_hunyuan3d_guidance_scale", text="Guidance Scale")
                 layout.prop(scene, "blendermcp_hunyuan3d_texture", text="Generate Texture")
-        
+
         if not scene.blendermcp_server_running:
             layout.operator("blendermcp.start_server", text="Connect to MCP server")
         else:
@@ -2164,7 +2272,7 @@ class BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey(bpy.types.Operator):
     bl_label = "Set Free Trial API Key"
 
     def execute(self, context):
-        context.scene.blendermcp_hyper3d_api_key = RODIN_FREE_TRIAL_KEY
+        set_api_key("hyper3d", RODIN_FREE_TRIAL_KEY)
         context.scene.blendermcp_hyper3d_mode = 'MAIN_SITE'
         self.report({'INFO'}, "API Key set successfully!")
         return {'FINISHED'}
@@ -2328,6 +2436,7 @@ def register():
         default=""
     )
 
+    bpy.utils.register_class(BlenderMCPPreferences)
     bpy.utils.register_class(BLENDERMCP_PT_Panel)
     bpy.utils.register_class(BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey)
     bpy.utils.register_class(BLENDERMCP_OT_StartServer)
@@ -2345,6 +2454,7 @@ def unregister():
     bpy.utils.unregister_class(BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey)
     bpy.utils.unregister_class(BLENDERMCP_OT_StartServer)
     bpy.utils.unregister_class(BLENDERMCP_OT_StopServer)
+    bpy.utils.unregister_class(BlenderMCPPreferences)
 
     del bpy.types.Scene.blendermcp_port
     del bpy.types.Scene.blendermcp_server_running


### PR DESCRIPTION
### **User description**
## Summary
- Add `BlenderMCPPreferences` class using Blender's AddonPreferences for persistent API key storage
- API keys (Sketchfab, Hyper3D, Hunyuan3D) now persist across Blender sessions without requiring users to save .blend files
- Backward compatible: falls back to scene properties if preferences not available

## Changes
- Added `get_api_key()` and `set_api_key()` helper functions
- Updated UI panel to display API key fields from preferences
- Updated all API calls to use the new helper functions

## Test Plan
- [x] Python syntax verified with Python 3.10+
- [ ] Install addon in Blender, enter API key, restart Blender, verify key persists

Closes #159


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implement persistent API key storage using Blender AddonPreferences

- Add helper functions for API key retrieval with backward compatibility

- Update all API calls to use new persistent storage mechanism

- Migrate UI panel to display API keys from preferences instead of scene properties


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scene Properties<br/>Old Storage"] -->|"Backward Compatibility"| B["get_api_key()"]
  C["AddonPreferences<br/>New Storage"] -->|"Primary Source"| B
  B -->|"Returns API Key"| D["API Calls<br/>Hyper3D, Sketchfab, Hunyuan3D"]
  E["UI Panel"] -->|"Reads/Writes"| C
  F["set_api_key()"] -->|"Writes"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>addon.py</strong><dd><code>Implement persistent API key storage with backward compatibility</code></dd></summary>
<hr>

addon.py

<ul><li>Add <code>BlenderMCPPreferences</code> class with persistent storage for Sketchfab, <br>Hyper3D, and Hunyuan3D API keys<br> <li> Implement <code>get_api_key()</code> helper function with fallback to scene <br>properties for backward compatibility<br> <li> Implement <code>set_api_key()</code> helper function to write API keys to <br>preferences<br> <li> Add <code>get_addon_preferences()</code> utility function to safely retrieve addon <br>preferences<br> <li> Update all API calls across Hyper3D, Sketchfab, and Hunyuan3D modules <br>to use <code>get_api_key()</code> instead of direct scene property access<br> <li> Modify UI panel to display API key fields from preferences when <br>available<br> <li> Register and unregister <code>BlenderMCPPreferences</code> class in addon lifecycle<br> <li> Bump addon version from 1.2 to 1.3</ul>


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/168/files#diff-a00fabecb6c13a84bae446368347ab0da61ce323e65e01afdbbbb9639cd17605">+134/-24</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced centralized addon preferences system for managing API keys persistently
  * Added dedicated UI panel for storing credentials across multiple services (Sketchfab, Hyper3D, Hunyuan3D)
  * Maintains full backward compatibility with existing configurations

* **Chores**
  * Refactored API key access throughout addon to use new centralized system

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->