### PR TITLE
Add Dockerfile for MCP registry integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir uv
+
+ENTRYPOINT ["uvx", "blender-mcp"]


### PR DESCRIPTION
## Summary

- Adds a Dockerfile that uses `uvx` to fetch and run `blender-mcp` from PyPI
- This enables the server to be included in the Docker MCP registry

## Details

The Dockerfile uses `python:3.12-slim` as a base image, installs `uv`, and uses `uvx blender-mcp` as the entrypoint — matching the recommended installation approach from the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker container support for simplified deployment and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->