### PR TITLE
Add Dockerfile for Docker MCP Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,7 @@ FROM python:3.12-slim
 
 RUN pip install --no-cache-dir uv
 
+ENV BLENDER_HOST=host.docker.internal
+ENV BLENDER_PORT=9876
+
 ENTRYPOINT ["uvx", "blender-mcp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM python:3.12-slim
 
 RUN pip install --no-cache-dir uv
 
+RUN groupadd --system appuser && useradd --system --gid appuser appuser
+
 ENV BLENDER_HOST=host.docker.internal
 ENV BLENDER_PORT=9876
+
+USER appuser
 
 ENTRYPOINT ["uvx", "blender-mcp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN groupadd --system appuser && useradd --system --gid appuser appuser
 
 ENV BLENDER_HOST=host.docker.internal
 ENV BLENDER_PORT=9876
+ENV DISABLE_TELEMETRY=true
 
 USER appuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ENV DISABLE_TELEMETRY=true
 
 USER appuser
 
-ENTRYPOINT ["uvx", "blender-mcp"]
+ENTRYPOINT ["uvx", "blender-mcp==1.5.5"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir uv
+
+ENTRYPOINT ["uvx", "blender-mcp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 RUN pip install --no-cache-dir uv
 
-RUN groupadd --system appuser && useradd --system --gid appuser appuser
+RUN groupadd --system appuser && useradd --system --gid appuser --create-home appuser
 
 ENV BLENDER_HOST=host.docker.internal
 ENV BLENDER_PORT=9876


### PR DESCRIPTION
## Summary

Adds a Dockerfile to enable containerized deployment via the [Docker MCP Registry](https://github.com/docker/mcp-registry).

- Uses `uvx` to run blender-mcp, consistent with the project's recommended installation approach
- Sets `BLENDER_HOST=host.docker.internal` so the container can reach Blender on the host
- Sets `BLENDER_PORT=9876` matching the default
- Disables telemetry by default (`DISABLE_TELEMETRY=true`) for containerized environments
- Runs as non-root user (`appuser`) for security

## Test plan

- [x] `docker build -t blender-mcp .` builds successfully
- [x] `docker run --rm blender-mcp` starts the MCP server (connects to Blender if addon is running)
- [x] Validated and built with Docker MCP Registry tooling (`task validate`, `task build --tools`)
- [x] Gateway discovers all 22 tools and 1 prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Containerized deployment added for simplified, reproducible installs.
  * Container runs the app via a preconfigured runtime and includes the 1.5.5 app release by default.
  * Runs as a non-root application user for improved security.
  * Networking and telemetry environment settings are preset for the container runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->