### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Give feedback, get inspired, and build on top of the MCP: [Discord](https://disc
 - Delete the MCP server from Claude and add it back again, and you should be good to go!
 
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ahujasid-blender-mcp).
+
 ## Features
 
 - **Two-way communication**: Connect Claude AI to Blender through a socket-based server


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ahujasid-blender-mcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Hosted deployment" section to the README, providing users with a link to access the hosted deployment service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->