### PR TITLE
Fix: replace removed ShaderNodeSeparateRGB with ShaderNodeSeparateColor (Blender 4.0+)

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -994,18 +994,21 @@ class BlenderMCPServer:
 
             # Handle ARM texture (Ambient Occlusion, Roughness, Metallic)
             if 'arm' in texture_nodes:
-                separate_rgb = nodes.new(type='ShaderNodeSeparateRGB')
+                # Blender 4.0+ removed ShaderNodeSeparateRGB. Use ShaderNodeSeparateColor
+                # (mode='RGB'); outputs are now Red/Green/Blue, input is Color.
+                separate_rgb = nodes.new(type='ShaderNodeSeparateColor')
+                separate_rgb.mode = 'RGB'
                 separate_rgb.location = (-200, -100)
-                links.new(texture_nodes['arm'].outputs['Color'], separate_rgb.inputs['Image'])
+                links.new(texture_nodes['arm'].outputs['Color'], separate_rgb.inputs['Color'])
 
                 # Connect Roughness (G) if no dedicated roughness map
                 if not any(map_name in texture_nodes for map_name in ['roughness', 'rough']):
-                    links.new(separate_rgb.outputs['G'], principled.inputs['Roughness'])
+                    links.new(separate_rgb.outputs['Green'], principled.inputs['Roughness'])
                     print("Connected ARM.G to Roughness")
 
                 # Connect Metallic (B) if no dedicated metallic map
                 if not any(map_name in texture_nodes for map_name in ['metallic', 'metalness', 'metal']):
-                    links.new(separate_rgb.outputs['B'], principled.inputs['Metallic'])
+                    links.new(separate_rgb.outputs['Blue'], principled.inputs['Metallic'])
                     print("Connected ARM.B to Metallic")
 
                 # For AO (R channel), multiply with base color if we have one
@@ -1028,7 +1031,7 @@ class BlenderMCPServer:
 
                     # Connect through the mix node
                     links.new(base_color_node.outputs['Color'], mix_node.inputs[1])
-                    links.new(separate_rgb.outputs['R'], mix_node.inputs[2])
+                    links.new(separate_rgb.outputs['Red'], mix_node.inputs[2])
                     links.new(mix_node.outputs['Color'], principled.inputs['Base Color'])
                     print("Connected ARM.R to AO mix with Base Color")
 


### PR DESCRIPTION
## Summary

Fixes `set_texture` failing in Blender 4.0+ with:

```
Error: Failed to apply texture: Error: Node type ShaderNodeSeparateRGB undefined
```

`ShaderNodeSeparateRGB` was removed in Blender 4.0 in favor of the unified `ShaderNodeSeparateColor` (added in 3.3) which exposes a `mode` property (`RGB` / `HSV` / `HSL`). The old node still appears in scenes loaded from older `.blend` files via legacy compatibility, but `nodes.new(type='ShaderNodeSeparateRGB')` raises the error above.

This breaks `set_texture` for any PolyHaven texture set that ships an ARM map — which is most of them.

## Changes

`addon.py`, ARM-handling block (~line 994):

| Before | After |
|---|---|
| `nodes.new(type='ShaderNodeSeparateRGB')` | `nodes.new(type='ShaderNodeSeparateColor')` + `mode='RGB'` |
| `inputs['Image']` | `inputs['Color']` |
| `outputs['R']` / `'G'` / `'B'` | `outputs['Red']` / `'Green'` / `'Blue'` |

## Compatibility

- Backward compatible with Blender 3.3+ (`ShaderNodeSeparateColor` was introduced in 3.3)
- Verified working in Blender 5.1.1 with PolyHaven textures (`brick_wall_003`, `clay_roof_tiles_03`, `dark_wooden_planks`, `aerial_grass_rock`) — full ARM channel routing confirmed (AO → Base Color multiply, Roughness from Green, Metallic from Blue)

## Test plan

- [x] `set_texture` no longer raises `Node type ShaderNodeSeparateRGB undefined` in Blender 5.1.1
- [x] Resulting material correctly routes ARM channels (AO/Roughness/Metallic) to Principled BSDF
- [x] Diffuse, Normal (gl/dx), Roughness, and Displacement maps still wire correctly
- [ ] Should be re-tested in Blender 3.x to confirm 3.3+ backward compatibility (I only have 5.1.1 locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture handling compatibility with Blender 4.0 and later versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->