### PR TITLE
New parameter for Rodin Gen-2.5

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -30,7 +30,7 @@ bl_info = {
     "category": "Interface",
 }
 
-RODIN_FREE_TRIAL_KEY = "k9TcfFoEhNd9cCPP2guHAHHHkctZHIRhZDywZ1euGUXwihbYLpOjQhofby80NJez"
+RODIN_FREE_TRIAL_KEY = "vibecoding"
 
 # Add User-Agent as required by Poly Haven API
 REQ_HEADERS = requests.utils.default_headers()
@@ -1189,8 +1189,9 @@ class BlenderMCPServer:
             """Call Rodin API, get the job uuid and subscription key"""
             files = [
                 *[("images", (f"{i:04d}{img_suffix}", img)) for i, (img_suffix, img) in enumerate(images)],
-                ("tier", (None, "Sketch")),
+                ("tier", (None, "Gen-2.5-Medium")),
                 ("mesh_mode", (None, "Raw")),
+                ("texture_mode", (None, "high")),
             ]
             if text_prompt:
                 files.append(("prompt", (None, text_prompt)))


### PR DESCRIPTION
Hi, I’m Eric from the Rodin Team.

We recently released Rodin Gen-2.5, and this PR updates part of the MAIN_SITE request parameters to use Gen-2.5.

Changes included:

Set MAIN_SITE tier to Gen-2.5-Medium
Add texture_mode=high for MAIN_SITE requests
Leave the fal.ai integration unchanged
Gen-2.5 provides significantly better 3D model generation quality, so this should improve the output quality for users generating models through the MAIN_SITE Rodin integration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hyper3D Rodin service integration with new model tier (Gen-2.5-Medium) and texture mode configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahujasid/blender-mcp/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->