### PR TITLE
fix: auto-start TCP server on addon registration

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -2596,6 +2596,16 @@ def register():
     bpy.utils.register_class(BLENDERMCP_OT_StopServer)
     bpy.utils.register_class(BLENDERMCP_OT_OpenTerms)
 
+    # Auto-start the server so the MCP client can connect without manual UI interaction
+    if not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server:
+        bpy.types.blendermcp_server = BlenderMCPServer(port=9876)
+    if not bpy.types.blendermcp_server.running:
+        bpy.types.blendermcp_server.start()
+        try:
+            bpy.context.scene.blendermcp_server_running = True
+        except AttributeError:
+            pass
+
     print("BlenderMCP addon registered")
 
 def unregister():

--- a/addon.py
+++ b/addon.py
@@ -2603,11 +2603,11 @@ def register():
     bpy.utils.register_class(BLENDERMCP_OT_OpenTerms)
 
     # Auto-start the server so the MCP client can connect without manual UI interaction
-    try:
-        scene = bpy.context.scene
+    scene = getattr(bpy.context, 'scene', None)
+    if scene is not None:
         port = scene.blendermcp_port
         auto_start = scene.blendermcp_auto_start_server
-    except AttributeError:
+    else:
         port = 9876
         auto_start = True
 
@@ -2637,6 +2637,7 @@ def unregister():
 
     del bpy.types.Scene.blendermcp_port
     del bpy.types.Scene.blendermcp_server_running
+    del bpy.types.Scene.blendermcp_auto_start_server
     del bpy.types.Scene.blendermcp_use_polyhaven
     del bpy.types.Scene.blendermcp_use_hyper3d
     del bpy.types.Scene.blendermcp_hyper3d_mode

--- a/addon.py
+++ b/addon.py
@@ -2480,6 +2480,12 @@ def register():
         default=False
     )
 
+    bpy.types.Scene.blendermcp_auto_start_server = bpy.props.BoolProperty(
+        name="Auto-Start Server",
+        description="Automatically start the MCP server when Blender loads",
+        default=True
+    )
+
     bpy.types.Scene.blendermcp_use_polyhaven = bpy.props.BoolProperty(
         name="Use Poly Haven",
         description="Enable Poly Haven asset integration",
@@ -2597,12 +2603,20 @@ def register():
     bpy.utils.register_class(BLENDERMCP_OT_OpenTerms)
 
     # Auto-start the server so the MCP client can connect without manual UI interaction
-    if not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server:
-        bpy.types.blendermcp_server = BlenderMCPServer(port=9876)
-    if not bpy.types.blendermcp_server.running:
+    try:
+        scene = bpy.context.scene
+        port = scene.blendermcp_port
+        auto_start = scene.blendermcp_auto_start_server
+    except AttributeError:
+        port = 9876
+        auto_start = True
+
+    if auto_start and (not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server):
+        bpy.types.blendermcp_server = BlenderMCPServer(port=port)
+    if auto_start and not bpy.types.blendermcp_server.running:
         bpy.types.blendermcp_server.start()
         try:
-            bpy.context.scene.blendermcp_server_running = True
+            bpy.context.scene.blendermcp_server_running = bpy.types.blendermcp_server.running
         except AttributeError:
             pass
 


### PR DESCRIPTION
The addon required users to manually click "Connect to MCP server" in Blender's 3D View sidebar every time Blender starts. This is easy to forget and makes the MCP integration feel unreliable.

Fix: Auto-start the TCP server at the end of register(). The server instance is created if missing and started if not already running. bpy.context.scene.blendermcp_server_running is set to True so the UI panel reflects the correct state.

Testing: Verified on Blender 5.1.2, macOS 15.4. Server starts on port 9876 immediately on addon load. uvx blender-mcp connects successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional auto-start for the MCP server when the addon loads (enabled by default).
  * Server uses the scene's configured port and falls back to port 9876 if unset.
  * Scene-level indicator will be updated to reflect the server's running state when that indicator exists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahujasid/blender-mcp/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->