### PR TITLE
Fix arbitrary file write in download_polyhaven_asset

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -751,8 +751,22 @@ class BlenderMCPServer:
                                 # Get the URL for the included file - this is the fix
                                 include_url = include_info["url"]
 
+                                # Validate include_path — the API response controls these
+                                # dict keys; a malicious or MITM'd response could request an
+                                # absolute path or one containing ".." to escape temp_dir
+                                # and write arbitrary files (e.g. ~/.bashrc, authorized_keys).
+                                # Mirrors the zip-slip check in download_sketchfab_model.
+                                target_path = os.path.join(temp_dir, os.path.normpath(include_path))
+                                abs_temp_dir = os.path.abspath(temp_dir)
+                                abs_target_path = os.path.abspath(target_path)
+                                if (os.path.isabs(include_path)
+                                        or ".." in include_path
+                                        or not abs_target_path.startswith(abs_temp_dir + os.sep)):
+                                    print(f"Skipping include with unsafe path: {include_path}")
+                                    continue
+
                                 # Create the directory structure for the included file
-                                include_file_path = os.path.join(temp_dir, include_path)
+                                include_file_path = target_path
                                 os.makedirs(os.path.dirname(include_file_path), exist_ok=True)
 
                                 # Download the included file


### PR DESCRIPTION
#257 

### summary

`BlenderMCPServer.download_polyhaven_asset` (models branch, [addon.py:755](https://github.com/ahujasid/blender-mcp/blob/main/addon.py#L755)) joins dict keys from the Poly Haven API `"include"` field directly into a filesystem path with no containment check. A malicious or MITM'd API response can set those keys to `../../.bashrc` or absolute paths and write arbitrary files anywhere the Blender process has write access.

### fix

Mirrors the existing zip-slip check in download_sketchfab_model ([addon.py:1750-1777](https://github.com/ahujasid/blender-mcp/blob/main/addon.py#L1750-L1777)):

- normalize the path with os.path.normpath
- reject absolute paths (os.path.isabs)
- reject any .. in the raw key
- require the resolved absolute path to start with abspath(temp_dir) + os.sep

Unsafe includes are skipped with a log message, not aborted — matches the existing convention on the same code path (a failed include download is already logged + skipped, not fatal). Legitimate model imports continue to work; only the malicious entry is dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security controls when processing asset include files. The system now validates all file paths and prevents path traversal attacks, ensuring downloaded assets are safely extracted to their intended locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahujasid/blender-mcp/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->