### PR TITLE
Derive __version__ from package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Give feedback, get inspired, and build on top of the MCP: [Discord](https://disc
 
 [Support this project](https://github.com/sponsors/ahujasid)
 
-## Current version(1.5.5)
+## Highlights
+
+For the current version and changelog, see the [releases page](https://github.com/ahujasid/blender-mcp/releases).
+
 - Added Hunyuan3D support
 - View screenshots for Blender viewport to better understand the scene
 - Search and download Sketchfab models
@@ -29,7 +32,7 @@ Give feedback, get inspired, and build on top of the MCP: [Discord](https://disc
 - Run Blender MCP on a remote host
 - Telemetry for tools executed (completely anonymous)
 
-### Installating a new version (existing users)
+### Installing a new version (existing users)
 - For newcomers, you can go straight to Installation. For existing users, see the points below
 - Download the latest addon.py file and replace the older one, then add it to Blender
 - Delete the MCP server from Claude and add it back again, and you should be good to go!

--- a/src/blender_mcp/__init__.py
+++ b/src/blender_mcp/__init__.py
@@ -1,6 +1,12 @@
 """Blender integration through the Model Context Protocol."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("blender-mcp")
+except PackageNotFoundError:
+    # Package is not installed (e.g. running from a source checkout)
+    __version__ = "unknown"
 
 # Expose key classes and functions for easier imports
 from .server import BlenderConnection, get_blender_connection


### PR DESCRIPTION
## Summary

The package version is currently duplicated in `pyproject.toml`, `src/blender_mcp/__init__.py`, and the README. This PR makes `pyproject.toml` the source of truth for `blender_mcp.__version__` and removes the stale README version heading.

## Changes

- Derive `blender_mcp.__version__` from installed package metadata.
- Fall back to `"unknown"` when the package metadata is unavailable in a source checkout.
- Replace the stale README version heading with a `Highlights` heading and a releases link.
- Fix the `Installating` typo.

## Not changed

`addon.py`'s `bl_info "version": (1, 2)` is left unchanged because Blender parses `bl_info` statically; changing that belongs to the release checklist.

## Verification

- Installed wheel: `blender_mcp.__version__` matches the package version.
- Source checkout without package metadata: `blender_mcp.__version__` falls back to `"unknown"`.

Fixes part of the version confusion in #268.
