### PR TITLE
Fail fast when Blender runs in background mode

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -45,6 +45,11 @@ class BlenderMCPServer:
         self.server_thread = None
 
     def start(self):
+        if bpy.app.background:
+            print("BlenderMCP: cannot start server in background mode (blender -b) - commands would never execute\n"
+                  "BlenderMCP: run Blender with a GUI, or use a virtual display: xvfb-run -a blender")
+            return
+
         if self.running:
             print("Server is already running")
             return
@@ -2426,7 +2431,7 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
 
         # Start the server
         bpy.types.blendermcp_server.start()
-        scene.blendermcp_server_running = True
+        scene.blendermcp_server_running = bpy.types.blendermcp_server.running
 
         return {'FINISHED'}
 

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -151,7 +151,7 @@ class BlenderConnection:
             # Don't try to reconnect here - let the get_blender_connection handle reconnection
             # Just invalidate the current socket so it will be recreated next time
             self.sock = None
-            raise Exception("Timeout waiting for Blender response - try simplifying your request")
+            raise Exception("Timeout waiting for Blender response - try simplifying your request. If Blender is running headless (blender -b), commands never execute; run Blender with a GUI or via 'xvfb-run -a blender' instead")
         except (ConnectionError, BrokenPipeError, ConnectionResetError) as e:
             logger.error(f"Socket connection error: {str(e)}")
             self.sock = None


### PR DESCRIPTION
## Summary

When Blender runs in background mode (`blender -b`), addon commands are scheduled through `bpy.app.timers`, but background mode does not run the timer loop needed to execute them. The server can appear connected while every command waits until the 180 second timeout.

This PR makes that unsupported mode fail fast with an explicit message.

## Changes

- Refuse to start the addon socket server when `bpy.app.background` is true.
- Tell users to run Blender with a GUI or with a virtual display such as `xvfb-run -a blender`.
- Keep the supported virtual-display path unaffected.
- Keep the Connect operator UI state in sync by reading back the actual server running state.
- Add a conditional headless-mode explanation to the server timeout message for users with mismatched addon/server versions.

## Verification

- `python3 -m py_compile addon.py`
- Server import/tool-list sanity check reports 22 tools.

Fixes #251 and improves the headless reports in #193 / #260.
