### PR TITLE
fix: use ShaderNodeSeparateColor for ARM map (Blender 4.0+)

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1064,18 +1064,18 @@ class BlenderMCPServer:
 
             # Handle ARM texture (Ambient Occlusion, Roughness, Metallic)
             if 'arm' in texture_nodes:
-                separate_rgb = nodes.new(type='ShaderNodeSeparateRGB')
+                separate_rgb = nodes.new(type='ShaderNodeSeparateColor')
                 separate_rgb.location = (-200, -100)
-                links.new(texture_nodes['arm'].outputs['Color'], separate_rgb.inputs['Image'])
+                links.new(texture_nodes['arm'].outputs['Color'], separate_rgb.inputs['Color'])
 
                 # Connect Roughness (G) if no dedicated roughness map
                 if not any(map_name in texture_nodes for map_name in ['roughness', 'rough']):
-                    links.new(separate_rgb.outputs['G'], principled.inputs['Roughness'])
+                    links.new(separate_rgb.outputs['Green'], principled.inputs['Roughness'])
                     print("Connected ARM.G to Roughness")
 
                 # Connect Metallic (B) if no dedicated metallic map
                 if not any(map_name in texture_nodes for map_name in ['metallic', 'metalness', 'metal']):
-                    links.new(separate_rgb.outputs['B'], principled.inputs['Metallic'])
+                    links.new(separate_rgb.outputs['Blue'], principled.inputs['Metallic'])
                     print("Connected ARM.B to Metallic")
 
                 # For AO (R channel), multiply with base color if we have one
@@ -1098,7 +1098,7 @@ class BlenderMCPServer:
 
                     # Connect through the mix node
                     links.new(base_color_node.outputs['Color'], mix_node.inputs[1])
-                    links.new(separate_rgb.outputs['R'], mix_node.inputs[2])
+                    links.new(separate_rgb.outputs['Red'], mix_node.inputs[2])
                     links.new(mix_node.outputs['Color'], principled.inputs['Base Color'])
                     print("Connected ARM.R to AO mix with Base Color")
 


### PR DESCRIPTION
## Problem

`set_texture` crashes on Blender 4.0+ whenever a Poly Haven texture includes an
ARM (AO / Roughness / Metallic) map:

```
Error: Failed to apply texture: Error: Node type ShaderNodeSeparateRGB undefined
```

`ShaderNodeSeparateRGB` was **removed in Blender 4.0**, replaced by
`ShaderNodeSeparateColor` (which has existed since Blender 3.3).

## Fix

Switch the ARM-map split to `ShaderNodeSeparateColor` and update the renamed
sockets:

- input `Image` → `Color`
- outputs `R` / `G` / `B` → `Red` / `Green` / `Blue`

5-line change in `addon.py`; the resulting node graph is unchanged.

## Testing

Blender 5.1.1:

1. `download_polyhaven_asset("brick_wall_001", "textures")`
2. `set_texture("Cube", "brick_wall_001")`

- **Before:** crash above.
- **After:** material applied successfully — ARM map wired through
  `Separate Color` (Green→Roughness, Blue→Metallic, Red→AO mix).

## Compatibility

`ShaderNodeSeparateColor` is available on Blender 3.3+, so this keeps working on
3.3–3.x and fixes 4.0–5.x.
