### PR TITLE
Fix set_texture on Blender 4.0+: version-guard ARM channel split (SeparateRGB removed in 4.0)

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1064,18 +1064,26 @@ class BlenderMCPServer:
 
             # Handle ARM texture (Ambient Occlusion, Roughness, Metallic)
             if 'arm' in texture_nodes:
-                separate_rgb = nodes.new(type='ShaderNodeSeparateRGB')
-                separate_rgb.location = (-200, -100)
-                links.new(texture_nodes['arm'].outputs['Color'], separate_rgb.inputs['Image'])
+                # Blender 4.0 removed ShaderNodeSeparateRGB (renamed to
+                # ShaderNodeSeparateColor, added in 3.3). Branch on the running
+                # Blender version so pre-4.0 behavior is untouched.
+                if bpy.app.version >= (4, 0):
+                    sep = nodes.new(type='ShaderNodeSeparateColor')  # defaults to mode='RGB'
+                    in_socket, ch_r, ch_g, ch_b = 'Color', 'Red', 'Green', 'Blue'
+                else:
+                    sep = nodes.new(type='ShaderNodeSeparateRGB')
+                    in_socket, ch_r, ch_g, ch_b = 'Image', 'R', 'G', 'B'
+                sep.location = (-200, -100)
+                links.new(texture_nodes['arm'].outputs['Color'], sep.inputs[in_socket])
 
                 # Connect Roughness (G) if no dedicated roughness map
                 if not any(map_name in texture_nodes for map_name in ['roughness', 'rough']):
-                    links.new(separate_rgb.outputs['G'], principled.inputs['Roughness'])
+                    links.new(sep.outputs[ch_g], principled.inputs['Roughness'])
                     print("Connected ARM.G to Roughness")
 
                 # Connect Metallic (B) if no dedicated metallic map
                 if not any(map_name in texture_nodes for map_name in ['metallic', 'metalness', 'metal']):
-                    links.new(separate_rgb.outputs['B'], principled.inputs['Metallic'])
+                    links.new(sep.outputs[ch_b], principled.inputs['Metallic'])
                     print("Connected ARM.B to Metallic")
 
                 # For AO (R channel), multiply with base color if we have one
@@ -1098,7 +1106,7 @@ class BlenderMCPServer:
 
                     # Connect through the mix node
                     links.new(base_color_node.outputs['Color'], mix_node.inputs[1])
-                    links.new(separate_rgb.outputs['R'], mix_node.inputs[2])
+                    links.new(sep.outputs[ch_r], mix_node.inputs[2])
                     links.new(mix_node.outputs['Color'], principled.inputs['Base Color'])
                     print("Connected ARM.R to AO mix with Base Color")
 

--- a/test_set_texture_version_guard.py
+++ b/test_set_texture_version_guard.py
@@ -1,0 +1,61 @@
+"""Static structural check for the set_texture ARM version guard.
+
+Blender 4.0 removed ShaderNodeSeparateRGB (renamed to ShaderNodeSeparateColor,
+added in 3.3). This test asserts addon.py branches on bpy.app.version and wires
+the correct socket names on each branch, without running Blender.
+"""
+import ast
+import pathlib
+
+ADDON = pathlib.Path(__file__).with_name("addon.py")
+
+
+def _source():
+    return ADDON.read_text()
+
+
+def test_addon_parses():
+    # The file must remain syntactically valid Python after the edit.
+    ast.parse(_source())
+
+
+def test_has_version_guard():
+    src = _source()
+    assert "bpy.app.version >= (4, 0)" in src, \
+        "expected a runtime guard `bpy.app.version >= (4, 0)`"
+
+
+def test_uses_separate_color_on_4x():
+    src = _source()
+    assert "ShaderNodeSeparateColor" in src, \
+        "expected ShaderNodeSeparateColor node for Blender 4.0+"
+
+
+def test_keeps_separate_rgb_for_legacy():
+    src = _source()
+    assert "ShaderNodeSeparateRGB" in src, \
+        "pre-4.0 path must keep the original ShaderNodeSeparateRGB node"
+
+
+def test_socket_name_locals_present():
+    # Both branches must bind the channel-name locals used downstream.
+    src = _source()
+    for token in ("in_socket", "ch_r", "ch_g", "ch_b"):
+        assert token in src, f"expected downstream channel local `{token}`"
+    # 4.0+ socket names
+    for token in ("'Color'", "'Red'", "'Green'", "'Blue'"):
+        assert token in src, f"expected 4.0+ socket name {token}"
+    # legacy socket names
+    for token in ("'Image'", "'R'", "'G'", "'B'"):
+        assert token in src, f"expected legacy socket name {token}"
+
+
+def test_no_literal_separate_rgb_output_indexing():
+    # After the fix, downstream wiring must go through ch_* locals,
+    # not `separate_rgb.outputs['G'|'B'|'R']` literals.
+    src = _source()
+    for bad in ("separate_rgb.outputs['G']",
+                "separate_rgb.outputs['B']",
+                "separate_rgb.outputs['R']"):
+        assert bad not in src, \
+            f"downstream wiring still uses literal {bad}; convert to ch_* local"


### PR DESCRIPTION
## Problem

`set_texture` fails on Blender 4.0+ whenever the applied PolyHaven texture set
includes a packed **ARM** map (Ambient Occlusion / Roughness / Metallic). The
ARM-handling code unconditionally creates a `ShaderNodeSeparateRGB` node to split
the packed channels:

```python
separate_rgb = nodes.new(type='ShaderNodeSeparateRGB')
```

Blender **4.0 removed** `ShaderNodeSeparateRGB` — it was renamed to
`ShaderNodeSeparateColor` (introduced in Blender **3.3**). On 4.0+ the call raises
`RuntimeError: Node type ShaderNodeSeparateRGB undefined` and texture application fails.

## Reproduction

1. Blender 4.0+ (reproduced on 5.1.2), add-on installed and "Connect to Claude" active.
2. Create a mesh (e.g. a plane).
3. `download_polyhaven_asset` a texture that ships an ARM map (e.g. `dark_wood`, 1k).
4. `set_texture` that texture onto the mesh.
5. Result: error creating `ShaderNodeSeparateRGB` (undefined node type on 4.0+);
   the texture is not applied.

## Fix

Branch on `bpy.app.version` and use the version-appropriate node + socket names:

- **Blender 4.0+**: `ShaderNodeSeparateColor` (defaults to `mode='RGB'`), input
  `Color`, outputs `Red`/`Green`/`Blue`.
- **Below 4.0**: the original `ShaderNodeSeparateRGB`, input `Image`, outputs
  `R`/`G`/`B` — **unchanged**.

All downstream channel wiring goes through `in_socket` / `ch_r` / `ch_g` / `ch_b`
locals, so both branches share one code path. The fix is **additive and backward
compatible**: the pre-4.0 behavior is byte-for-byte the same node and sockets as
before. `SeparateColor` was added in 3.3 and `SeparateRGB` removed in 4.0, so the
`>= (4, 0)` boundary is the correct cutover.

A small static test (`test_set_texture_version_guard.py`) asserts the guard, both
branches, and the socket-name locals without requiring Blender.

## Verification

Verified on **Blender 5.1.2** by running the fixed, version-guarded ARM-split
logic against a real `download_polyhaven_asset('dark_wood', 1k)` material (which
ships a packed ARM map):

- The guard takes the `>= (4, 0)` branch and creates a single
  `ShaderNodeSeparateColor` node (inputs `['Color']`, outputs
  `['Red','Green','Blue']`); no `ShaderNodeSeparateRGB` is created.
- The ARM map wires into the Separate Color node; Metallic is driven from the
  Blue output and AO from the Red output (mixed into Base Color). Roughness is
  correctly left off the ARM split because `dark_wood` ships a dedicated Rough map.
- An EEVEE render shows the material displaying correctly on the mesh.

**Only Blender 5.1 was available for testing**, so the pre-4.0 branch is
code-reviewed (it reproduces the original node/socket names exactly) rather than
run locally.